### PR TITLE
fix(npm): fix hanging shells

### DIFF
--- a/app/utils/shell.ts
+++ b/app/utils/shell.ts
@@ -11,6 +11,7 @@ export async function newShellProcess(webcontainer: WebContainer, terminal: ITer
       cols: terminal.cols ?? 80,
       rows: terminal.rows ?? 15,
     },
+    env: { npm_config_yes: true },
   });
 
   const input = process.input.getWriter();


### PR DESCRIPTION
This fixes the hanging shells when the AI forgets to include `--yes` in `npx` or `npm create`