### PR TITLE
fix: remove unnecessary convertToCoreMessages

### DIFF
--- a/app/lib/.server/llm/stream-text.ts
+++ b/app/lib/.server/llm/stream-text.ts
@@ -1,4 +1,4 @@
-import { streamText as _streamText, convertToCoreMessages } from 'ai';
+import { streamText as _streamText } from 'ai';
 import { getAPIKey } from '~/lib/.server/llm/api-key';
 import { getAnthropicModel } from '~/lib/.server/llm/model';
 import { MAX_TOKENS } from './constants';
@@ -29,7 +29,7 @@ export function streamText(messages: Messages, env: Env, options?: StreamingOpti
     headers: {
       'anthropic-beta': 'max-tokens-3-5-sonnet-2024-07-15',
     },
-    messages: convertToCoreMessages(messages),
+    messages,
     ...options,
   });
 }


### PR DESCRIPTION
No longer needed as noted here: https://sdk.vercel.ai/docs/reference/ai-sdk-ui/convert-to-core-messages