### PR TITLE
Update CONTRIBUTING.md for repo rename 

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Before you begin, ensure you have the following installed:
 1. Clone the repository (if you haven't already):
 
 ```bash
-git clone https://github.com/coleam00/bolt.new-any-llm.git
+git clone https://github.com/stackblitz-labs/bolt.diy.git
 ```
 
 2. Install dependencies:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -47,7 +47,7 @@ Before you begin, ensure you have the following installed:
 1. Clone the repository (if you haven't already):
 
 ```bash
-git clone https://github.com/stackblitz/bolt.new.git
+git clone https://github.com/coleam00/bolt.new-any-llm.git
 ```
 
 2. Install dependencies:


### PR DESCRIPTION
Updated the `git clone` command in CONTRIBUTING.md to reflect the repository name change to `stackblitz-labs/bolt.diy`.